### PR TITLE
Change hook callback to string

### DIFF
--- a/db/hooks.php
+++ b/db/hooks.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
 $callbacks = [
     [
         'hook' => \core\hook\output\before_http_headers::class,
-        'callback' => [\tool_redirects\hook_callbacks::class, 'before_http_headers'],
+        'callback' => '\tool_redirects\hook_callbacks::before_http_headers',
         'priority' => 0,
     ],
 ];

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024052000;
-$plugin->release   = 2024052000; // Match release exactly to version.
+$plugin->version   = 2024052400;
+$plugin->release   = 2024052400; // Match release exactly to version.
 $plugin->requires  = 2017051500; // Moodle 3.3.
 $plugin->component = 'tool_redirects';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Changes the new hook callback back to a string for greater compatibility as it was causing some issues in 4.3, for example https://github.com/catalyst/moodle-auth_outage/issues/336