### PR TITLE
Fix admin setting default

### DIFF
--- a/settings.php
+++ b/settings.php
@@ -33,7 +33,7 @@ if (is_siteadmin()) {
     $name = 'tool_redirects/rules';
     $title = get_string('rules', 'tool_redirects');
     $description = get_string('rules_desc', 'tool_redirects');
-    $default = null;
+    $default = '';
     $setting = new admin_setting_configtextarea($name, $title, $description, $default);
     $settings->add($setting);
 


### PR DESCRIPTION
null seems to be an invalid default, as it won't be set during command line installs and will instead pop up for the user to confirm.

This also fails a unit test added in MDL-78543 in 4.3

```
1) core\adminlib_test::test_admin_output_new_settings_by_page
Failed asserting that two arrays are identical.
--- Expected
+++ Actual
@@ @@
-Array &0 ()
+Array &0 (
+    'tool_redirects' => '-->New settings - Redirects\n
+<fieldset class="adminsettings">\n
+<div class="clearer"><!-- --></div>\n
+<div class="form-item row" id="admin-rules">\n
+    <div class="form-label col-sm-3 text-sm-right">\n
+            <label for="id_s_tool_redirects_rules">\n
+                Redirect settings\n
+            </label>\n
+        <span class="form-shortname d-block small text-muted">tool_redirects | rules</span>\n
+    </div>\n
+    <div class="form-setting col-sm-9">\n
+        <div class="form-textarea">\n
+    <textarea  rows="8" cols="60" id="id_s_tool_redirects_rules" name="s_tool_redirects_rules" spellcheck="true" class="form-control text-ltr"></textarea>\n
+</div>\n
+        <div class="form-description mt-3"><p>Each line should be a redirect rule like [php regex of URL to redirect from]=>[URL to redirect to]. Take care to escape / and . and ? in urls correctly, eg:</p>\n
+\n
+<pre>\n
+#\/my#=>/course/view.php?id=123\n
+#\/course\/view\.php\?id=123#=>/some-target\n
+#\/index\.php#=>/some-other-page\n
+#\/index\.php#=>https://some.other.site.com/\n
+</pre>\n
+\n
+<p>You can redirect from pages which do not exist as long as you have error pages setup correctly, see:\n
+<a href="https://docs.moodle.org/dev/Error_pages">https://docs.moodle.org/dev/Error_pages</a></p>\n
+</div>\n
+        \n
+    </div>\n
+</div></fieldset>'
+)

/var/www/moodle-44/lib/tests/adminlib_test.php:151
/var/www/moodle-44/lib/phpunit/classes/advanced_testcase.php:72

```