### PR TITLE
Add manage capability and move rules to own page

### DIFF
--- a/classes/form/manage.php
+++ b/classes/form/manage.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Form to manage redirect rules.
+ *
+ * @package    tool_redirects
+ * @author     Benjamin Walker <benjaminwalker@catalyst-au.net>
+ * @copyright  2024, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace tool_redirects\form;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once("$CFG->libdir/formslib.php");
+
+/**
+ * Manage redirects form.
+ */
+class manage extends \moodleform {
+    /** @var array config settings attached to the form */
+    protected const FORM_CONFIG = [
+        'rules',
+    ];
+
+    /** @var array config */
+    protected $config;
+
+    /**
+     * Form definition
+     *
+     * @return void
+     */
+    public function definition(): void {
+        global $CFG, $DB, $USER;
+
+        $mform = $this->_form;
+
+        // Rules.
+        $mform->addElement('textarea', 'rules', get_string('rules', 'tool_redirects'), ['cols' => 60, 'rows' => 8]);
+        $mform->setType('rules', PARAM_RAW);
+        $mform->addElement('static', 'rules_help', '', get_string('rules_desc', 'tool_redirects'));
+
+        $this->add_action_buttons(false);
+    }
+
+    /**
+     * Loads the current values of the form config.
+     * @return void
+     */
+    public function load_form_config(): void {
+        $config = [];
+        foreach (self::FORM_CONFIG as $name) {
+            $config[$name] = get_config('tool_redirects', $name);
+        }
+
+        // Save empty config values but don't set them. Needed for comparisons.
+        $this->config = $config;
+        $this->set_data(array_filter($config));
+    }
+
+    /**
+     * Saves the new form data to config.
+     * @param \stdClass $data submitted data
+     * @return void
+     */
+    public function save_form_config(\stdClass $data): void {
+        foreach ($data as $key => $value) {
+            if (in_array($key, self::FORM_CONFIG) && $value !== $this->config[$key]) {
+                set_config($key, $value, 'tool_redirects');
+                add_to_config_log($key, (string) $this->config[$key], $value, 'tool_redirects');
+            }
+        }
+    }
+}

--- a/classes/helper.php
+++ b/classes/helper.php
@@ -111,7 +111,7 @@ abstract class helper {
                     \core\notification::info(get_string('redirectwarning', 'tool_redirects', [
                         'target'  => $target->out(),
                         'regex'   => $rule->get_regex(),
-                        'editurl' => (new \moodle_url('/admin/settings.php?section=tool_redirects'))->out(),
+                        'editurl' => (new \moodle_url('/admin/tool/redirects/index.php'))->out(),
                     ]));
                     break;
                 }

--- a/db/access.php
+++ b/db/access.php
@@ -15,19 +15,25 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Version details.
+ * Capabilities.
+ *
+ * This files lists capabilities related to tool_redirects.
  *
  * @package    tool_redirects
- * @author     Dmitrii Metelkin <dmitriim@catalyst-au.net>
- * @copyright  2018 Catalyst IT Australia {@link http://www.catalyst-au.net}
+ * @author     Benjamin Walker <benjaminwalker@catalyst-au.net>
+ * @copyright  2024, Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2024120200;
-$plugin->release   = 2024120200; // Match release exactly to version.
-$plugin->requires  = 2017051500; // Moodle 3.3.
-$plugin->component = 'tool_redirects';
-$plugin->maturity  = MATURITY_STABLE;
-$plugin->supported = [33, 405];     // Supports Moodle 3.5 or later.
+$capabilities = [
+    'tool/redirects:manage' => [
+        'riskbitmask' => RISK_XSS | RISK_CONFIG,
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_SYSTEM,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ],
+    ],
+];

--- a/index.php
+++ b/index.php
@@ -1,0 +1,57 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Page to manage redirect rules
+ *
+ * @package    tool_redirects
+ * @author     Benjamin Walker <benjaminwalker@catalyst-au.net>
+ * @copyright  2024, Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+require_once(__DIR__ . '/../../../config.php');
+
+// This is locked behind a separate capability so the task can be delegated to non-admins.
+require_login();
+$context = context_system::instance();
+require_capability('tool/redirects:manage', $context);
+
+// Set up the page.
+$url = new moodle_url('/admin/tool/redirects/index.php');
+$PAGE->set_url($url);
+$PAGE->set_context($context);
+$PAGE->set_pagelayout('admin');
+$PAGE->set_title(get_string('redirects:manage', 'tool_redirects'));
+$PAGE->set_heading($SITE->fullname);
+
+// Create the form and load current config.
+$mform = new \tool_redirects\form\manage();
+$mform->load_form_config();
+
+// Handle form submission.
+if ($mform->is_cancelled()) {
+    redirect(new moodle_url('/'));
+} else if ($data = $mform->get_data()) {
+    $mform->save_form_config($data);
+    redirect($url, get_string('changessaved'), null, \core\output\notification::NOTIFY_SUCCESS);
+}
+
+// Display the form.
+echo $OUTPUT->header();
+echo $OUTPUT->heading(get_string('redirects:manage', 'tool_redirects'));
+$mform->display();
+echo $OUTPUT->footer();

--- a/lang/en/tool_redirects.php
+++ b/lang/en/tool_redirects.php
@@ -43,6 +43,7 @@ $string['redirectadmin_desc'] = "If enabled site administrators will be redirect
 $string['redirectwarning'] = '<p>This pages url matched a regex: <code>{$a->regex}</code> and so would have redirected to:<p>
 <a href="{$a->target}">{$a->target}</a>
 <p>You are seeing this because you are able to <a href="{$a->editurl}">edit the redirect configuration</a>.</p>';
+$string['redirects:manage'] = 'Manage redirect rules';
 $string['regex_error_too_short'] = 'RegEx too short';
 $string['regex_error_malformed'] = 'Invalid (malformed) RegEx';
 $string['privacy:metadata'] = 'The Redirects plugin does not store any personal data.';

--- a/settings.php
+++ b/settings.php
@@ -27,15 +27,18 @@ defined('MOODLE_INTERNAL') || die();
 
 if (is_siteadmin()) {
 
-    $settings = new admin_settingpage('tool_redirects', get_string('pluginname', 'tool_redirects'));
-    $ADMIN->add('tools', $settings);
+    $category = new admin_category('tool_redirects', get_string('pluginname', 'tool_redirects'));
+    $ADMIN->add('tools', $category);
 
-    $name = 'tool_redirects/rules';
-    $title = get_string('rules', 'tool_redirects');
-    $description = get_string('rules_desc', 'tool_redirects');
-    $default = '';
-    $setting = new admin_setting_configtextarea($name, $title, $description, $default);
-    $settings->add($setting);
+    $settings = new admin_settingpage('tool_redirects_settings', get_string('generalsettings', 'admin'));
+    $ADMIN->add('tool_redirects', $settings);
+
+    $ADMIN->add('tool_redirects', new admin_externalpage(
+        'tool_redirects_manage',
+        get_string('redirects:manage', 'tool_redirects'),
+        new moodle_url('/admin/tool/redirects/index.php'),
+        'tool/redirects:manage'
+    ));
 
     $name = 'tool_redirects/redirectadmin';
     $title = get_string('redirectadmin', 'tool_redirects');


### PR DESCRIPTION
Adds a separate capability so non admins can also manage redirects.

Switching this to a form is a bit messy, but I couldn't find any other way to do this. Similar to https://github.com/catalyst/moodle-tool_emailtemplate/pull/26