### PR TITLE
#38 : Fix Unit test static function

### DIFF
--- a/tests/phpunit/regex_validator_test.php
+++ b/tests/phpunit/regex_validator_test.php
@@ -36,7 +36,7 @@ final class regex_validator_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function provider_for_test_it_validates_the_regex(): array {
+    public static function provider_for_test_it_validates_the_regex(): array {
         return [
             'Empty RegEx is valid.'            => ['', true],
             'RegEx is too short'               => ['//', true],
@@ -67,7 +67,7 @@ final class regex_validator_test extends \advanced_testcase {
      *
      * @return array
      */
-    public function provider_for_test_it_throws_exception_if_regex_is_not_string(): array {
+    public static function provider_for_test_it_throws_exception_if_regex_is_not_string(): array {
         return [
             [[1]],
             [new \stdClass()],


### PR DESCRIPTION
Closes issue #38 .

## Environment
Moodle 5.1
PHP version: 8.4
PHP Unittest version: 11.5.55
Branch: MOODLE_401_STABLE

## Testing instructions:

Run `vendor/bin/phpunit public/admin/tool/redirects/tests/phpunit/regex_validator_test.php`

Output without fix
```
There were 2 PHPUnit errors:

1) tool_redirects\regex_validator_test::test_it_validates_the_regex
The data provider specified for tool_redirects\regex_validator_test::test_it_validates_the_regex is invalid
Data Provider method tool_redirects\regex_validator_test::provider_for_test_it_validates_the_regex() is not static

/var/www/site/public/admin/tool/redirects/tests/phpunit/regex_validator_test.php:59

2) tool_redirects\regex_validator_test::test_it_throws_exception_if_regex_is_not_string
The data provider specified for tool_redirects\regex_validator_test::test_it_throws_exception_if_regex_is_not_string is invalid
Data Provider method tool_redirects\regex_validator_test::provider_for_test_it_throws_exception_if_regex_is_not_string() is not static

/var/www/site/public/admin/tool/redirects/tests/phpunit/regex_validator_test.php:83

There were 4 PHPUnit test runner warnings:
3) No tests found in class "tool_redirects\regex_validator_test".

```


Expected output
```
root@735b528fc78d:/var/www/test# vendor/bin/phpunit public/admin/tool/redirects/tests/phpunit/regex_validator_test.php
Moodle 5.1.4 (Build: 20260420)
Php: 8.3.30, mysqli: 8.4.8, OS: Linux 6.17.0-35-generic x86_64
PHPUnit 11.5.55 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.3.30
Configuration: /var/www/osbc/phpunit.xml

............                                                      12 / 12 (100%)

Time: 00:00.830, Memory: 82.50 MB

OK, but there were issues!
Tests: 12, Assertions: 12, PHPUnit Deprecations: 2.
```