### PR TITLE
crafted nested query params crash every page

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -98,13 +98,8 @@ abstract class helper {
             return;
         }
 
-        // Exclude CLI scripts.
-        if (CLI_SCRIPT) {
-            return;
-        }
-
-        // Exclude web service requests.
-        if (WS_SERVER) {
+        // Exclude requests where a redirect is meaningless: web services, CLI and AJAX.
+        if (WS_SERVER || CLI_SCRIPT || (defined('AJAX_SCRIPT') && AJAX_SCRIPT)) {
             return;
         }
 

--- a/classes/redirect_rule.php
+++ b/classes/redirect_rule.php
@@ -99,7 +99,19 @@ class redirect_rule {
             return false;
         }
 
-        return (preg_match($this->config->regex, $url->out_as_local_url()) == 1);
+        try {
+            $localurl = $url->out_as_local_url();
+        } catch (\Throwable $e) {
+            // core\url::get_query_string() throws a TypeError when the URL carries deeply
+            // nested array query params (e.g. ?criteria[0][key]=...). A URL we cannot even
+            // encode can never match a rule, so don't let it fatal the request - catch
+            // \Throwable (an Error, not an Exception) and treat the rule as not matching.
+            debugging('tool_redirects: could not encode URL for rule matching: ' .
+                $e->getMessage(), DEBUG_DEVELOPER);
+            return false;
+        }
+
+        return (preg_match($this->config->regex, $localurl) == 1);
     }
 
     /**

--- a/tests/phpunit/redirect_rule_test.php
+++ b/tests/phpunit/redirect_rule_test.php
@@ -161,4 +161,23 @@ final class redirect_rule_test extends \advanced_testcase {
         $rule = new \tool_redirects\redirect_rule($config, $validator);
         $this->assertFalse($rule->should_redirect(new \moodle_url('http://example.com/index.php')));
     }
+
+    /**
+     * Test that a URL with deeply nested array query params does not fatal rule matching.
+     *
+     * core\url::get_query_string() throws a TypeError on such URLs; the rule must treat it
+     * as not matching instead of letting the error bubble up and kill the request.
+     */
+    public function test_should_not_redirect_on_nested_array_url(): void {
+        $this->configdata['regex'] = '#.*#'; // Matches anything, so a match would normally fire.
+
+        $config = new \tool_redirects\rule_config($this->configdata);
+        $validator = new \tool_redirects\regex_validator($config->regex);
+        $rule = new \tool_redirects\redirect_rule($config, $validator);
+
+        $url = new \moodle_url('http://example.com/index.php', ['criteria' => [['key' => 'parent']]]);
+
+        $this->assertFalse($rule->should_redirect($url));
+        $this->assertDebuggingCalled();
+    }
 }

--- a/tests/phpunit/redirect_rule_test.php
+++ b/tests/phpunit/redirect_rule_test.php
@@ -175,7 +175,10 @@ final class redirect_rule_test extends \advanced_testcase {
         $validator = new \tool_redirects\regex_validator($config->regex);
         $rule = new \tool_redirects\redirect_rule($config, $validator);
 
-        $url = new \moodle_url('http://example.com/index.php', ['criteria' => [['key' => 'parent']]]);
+        // Pass the nested array via the query string, not the params argument: moodle_url::params()
+        // rejects array values outright, but the constructor parse_str()'s a raw query straight into
+        // $params, which is exactly how such a URL reaches us from a real request.
+        $url = new \moodle_url('http://example.com/index.php?criteria[0][key]=parent');
 
         $this->assertFalse($rule->should_redirect($url));
         $this->assertDebuggingCalled();


### PR DESCRIPTION
Any URL with a deeply nested array query param — e.g. ?a[b][c]=1 — fatals the request with an uncaught TypeError:

rawurlencode(): Argument #1 ($string) must be of type string, array given at lib/classes/url.php  (core\url::get_query_string)
  
tool_redirects runs on every request via the after_config/before_http_headers hooks and builds a core\url of the current request to match it against the rules. core\url::get_query_string() only unwraps one level of array params, so a two-level-nested param hands an array to rawurlencode() and throws. Because it's an Error (not an Exception), it bubbles all the way up and 500s the page.

Impact: an unauthenticated visitor can 500 any page (including the front page) by appending a nested param. On web-service endpoints it's masked further by Moodle's early WS exception handler, making it hard to diagnose.

**Fix**
 - should_redirect() now wraps out_as_local_url() in a try/catch (\Throwable). A URL that can't even be encoded can't match a rule, so it's treated as a non-match and logged via debugging() instead of fataling the request.
- Also exclude AJAX requests from rule processing, alongside the existing CLI/web-service exclusions (a redirect is meaningless to an XHR).
  
**Tests**

Adds test_should_not_redirect_on_nested_array_url — drives a ?criteria[0][key]=... URL through rule matching and asserts no crash.