### PR TITLE
issue#17: Add login-state redirect rules and full-URL matching

### DIFF
--- a/classes/helper.php
+++ b/classes/helper.php
@@ -77,6 +77,7 @@ abstract class helper {
                         'redirecturl' => $data[1],
                         'enabled' => true,
                         'redirectadmin' => isset($config->redirectadmin) ? $config->redirectadmin : false,
+                        'loginstate' => isset($data[2]) ? trim($data[2]) : '',
                     ]);
 
                     $rules[] = new redirect_rule($ruleconfig, new regex_validator($ruleconfig->regex));

--- a/classes/redirect_rule.php
+++ b/classes/redirect_rule.php
@@ -77,6 +77,15 @@ class redirect_rule {
         return $this->config->regex;
     }
 
+    /**
+     * Return the login state condition for this rule.
+     * '' = everyone, 'loggedout' = guests/not-logged-in, 'loggedin' = authenticated users.
+     *
+     * @return string
+     */
+    public function get_loginstate() {
+        return $this->config->loginstate;
+    }
 
     /**
      * Check if we should redirect from provided URL.
@@ -96,6 +105,17 @@ class redirect_rule {
 
         // Check valid rule.
         if (!$this->validator->is_valid()) {
+            return false;
+        }
+
+        // Check login state condition.
+        $loginstate = $this->config->loginstate;
+        if ($loginstate === 'loggedout' && isloggedin() && !isguestuser()) {
+            // Rule is for logged-out users only, but user is logged in.
+            return false;
+        }
+        if ($loginstate === 'loggedin' && (!isloggedin() || isguestuser())) {
+            // Rule is for logged-in users only, but user is not logged in.
             return false;
         }
 

--- a/classes/rule_config.php
+++ b/classes/rule_config.php
@@ -58,6 +58,15 @@ class rule_config {
     protected $redirectadmin = false;
 
     /**
+     * Login state condition for this rule.
+     * '' = apply to everyone, 'loggedout' = apply only to guests/not-logged-in, 'loggedin' = apply only to logged-in users.
+     *
+     * @var string
+     */
+    protected $loginstate = '';
+
+
+    /**
      * Constructor.
      *
      * @param array $data Config data for a rule.

--- a/lang/en/tool_redirects.php
+++ b/lang/en/tool_redirects.php
@@ -43,6 +43,13 @@ $string['rules_desc'] = '<p>Each line should be a redirect rule like [php regex 
 #\/index\.php#=>/some-other-page
 #\/index\.php#=>https://some.other.site.com/
 </pre>
+<p>You can optionally append a third <code>=></code> segment to apply the rule only to logged-out or logged-in users:</p>
+<pre>
+#\/index\.php#=>/login/index.php=>loggedout
+#\/dashboard#=>/login/index.php=>loggedout
+#\/index\.php#=>/home=>loggedin
+</pre>
+<p>Supported values: <code>loggedout</code> (guests / not authenticated), <code>loggedin</code> (authenticated users). Omit the third segment to redirect everyone.</p>
 <p>You can also use the following tokens in the redirect url which will be dynamcially added:<p>
 <pre>
 [SESSKEY] - use with care to not open up XSS vulnerabilities

--- a/tests/phpunit/helper_test.php
+++ b/tests/phpunit/helper_test.php
@@ -93,4 +93,22 @@ final class helper_test extends \advanced_testcase {
         $this->assertEquals(true, $rules[1]->is_enabled());
         $this->assertEquals('url2.com', $rules[1]->get_redirect_url()->get_host());
     }
+
+    /**
+     * Test that loginstate is correctly parsed from the third '=>' segment of a rule line.
+     */
+    public function test_build_rules_parses_loginstate(): void {
+        set_config('rules', implode("\n", [
+            "#\/index\.php#=>/login/index.php=>loggedout",
+            "#\/dashboard#=>/login/index.php=>loggedin",
+            "#\/other#=>/somewhere",
+        ]), 'tool_redirects');
+
+        $rules = \tool_redirects\helper::build_rules_from_config();
+
+        $this->assertCount(3, $rules);
+        $this->assertEquals('loggedout', $rules[0]->get_loginstate());
+        $this->assertEquals('loggedin', $rules[1]->get_loginstate());
+        $this->assertEquals('', $rules[2]->get_loginstate());
+    }
 }

--- a/tests/phpunit/redirect_rule_test.php
+++ b/tests/phpunit/redirect_rule_test.php
@@ -188,4 +188,83 @@ final class redirect_rule_test extends \advanced_testcase {
         $this->assertFalse($rule->should_redirect($url));
         $this->assertDebuggingCalled();
     }
+
+    /**
+     * Test that an empty loginstate redirects everyone (logged-in and logged-out).
+     */
+    public function test_loginstate_empty_redirects_everyone(): void {
+        $this->configdata['regex'] = '#\/index\.php#';
+        $this->configdata['loginstate'] = '';
+
+        $config = new \tool_redirects\rule_config($this->configdata);
+        $validator = new \tool_redirects\regex_validator($config->regex);
+        $rule = new \tool_redirects\redirect_rule($config, $validator);
+        $url = new \moodle_url('http://example.com/index.php');
+
+        // Guest (not logged in) — should redirect.
+        $this->setGuestUser();
+        $this->assertTrue($rule->should_redirect($url));
+
+        // Authenticated user — should also redirect.
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+        $this->assertTrue($rule->should_redirect($url));
+    }
+
+    /**
+     * Test that loginstate 'loggedout' redirects only guests/not-logged-in users.
+     */
+    public function test_loginstate_loggedout_redirects_only_guests(): void {
+        $this->configdata['regex'] = '#\/index\.php#';
+        $this->configdata['loginstate'] = 'loggedout';
+
+        $config = new \tool_redirects\rule_config($this->configdata);
+        $validator = new \tool_redirects\regex_validator($config->regex);
+        $rule = new \tool_redirects\redirect_rule($config, $validator);
+        $url = new \moodle_url('http://example.com/index.php');
+
+        // Guest (not logged in) — should redirect.
+        $this->setGuestUser();
+        $this->assertTrue($rule->should_redirect($url));
+
+        // Authenticated user — should NOT redirect.
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+        $this->assertFalse($rule->should_redirect($url));
+    }
+
+    /**
+     * Test that loginstate 'loggedin' redirects only authenticated users.
+     */
+    public function test_loginstate_loggedin_redirects_only_authenticated(): void {
+        $this->configdata['regex'] = '#\/index\.php#';
+        $this->configdata['loginstate'] = 'loggedin';
+
+        $config = new \tool_redirects\rule_config($this->configdata);
+        $validator = new \tool_redirects\regex_validator($config->regex);
+        $rule = new \tool_redirects\redirect_rule($config, $validator);
+        $url = new \moodle_url('http://example.com/index.php');
+
+        // Guest (not logged in) — should NOT redirect.
+        $this->setGuestUser();
+        $this->assertFalse($rule->should_redirect($url));
+
+        // Authenticated user — should redirect.
+        $user = $this->getDataGenerator()->create_user();
+        $this->setUser($user);
+        $this->assertTrue($rule->should_redirect($url));
+    }
+
+    /**
+     * Test that get_loginstate returns the configured value.
+     */
+    public function test_get_loginstate_returns_configured_value(): void {
+        foreach (['', 'loggedout', 'loggedin'] as $state) {
+            $this->configdata['loginstate'] = $state;
+            $config = new \tool_redirects\rule_config($this->configdata);
+            $validator = new \tool_redirects\regex_validator($config->regex);
+            $rule = new \tool_redirects\redirect_rule($config, $validator);
+            $this->assertEquals($state, $rule->get_loginstate());
+        }
+    }
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026020303;
-$plugin->release   = 2026020303; // Match release exactly to version.
+$plugin->version   = 2026020304;
+$plugin->release   = 2026020304; // Match release exactly to version.
 $plugin->requires  = 2022112800; // Moodle 4.1.
 $plugin->component = 'tool_redirects';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
## Summary

Adds support for auth-state-aware redirect rules, based on the use case discussed in #17.

Redirect rules can now optionally include a third => segment to control whether the rule applies to:
- everyone
- only logged-out users
- only logged-in users

This keeps the existing textarea rule format while allowing redirects to behave differently for guests and authenticated users.

## Rule format

Existing format:

~~~text
[regex]=>[redirect-url]
~~~

New optional format:

~~~text
[regex]=>[redirect-url]=>[loginstate]
~~~

Supported loginstate values:
- empty: apply to everyone
- loggedout: apply only to guests / unauthenticated users
- loggedin: apply only to authenticated users

Examples:

~~~text
#\/index\.php#=>/login/index.php=>loggedout
#\/index\.php#=>/my=>loggedin
#\/dashboard#=>/some-page
~~~

## Changes included

- added loginstate to rule configuration
- parsed the optional third segment from configured redirect rules
- applied auth-state checks during redirect matching
- updated the admin help text with the new syntax and examples
- added PHPUnit coverage for parsing and redirect behavior

## Testing

Manual checks performed:
- verify a loggedout rule redirects guests
- verify a loggedout rule does not redirect authenticated users
- verify a loggedin rule redirects authenticated users
- verify a loggedin rule does not redirect guests
- verify a rule without a third segment still applies to everyone

Unit test coverage added for:
- parsing loginstate from rule config
- empty loginstate
- loggedout
- loggedin
- exposing configured loginstate
