### PR TITLE
Issue #44: Add support for full URL redirect rule

### DIFF
--- a/classes/redirect_rule.php
+++ b/classes/redirect_rule.php
@@ -99,8 +99,12 @@ class redirect_rule {
             return false;
         }
 
+        // Match against the local path (default) or the full URL including the host.
+        // Matching the full URL allows targeting a specific tenant/custom domain,
+        // e.g. #^http://example.com\/(index\.php)?#.
         try {
             $localurl = $url->out_as_local_url();
+            $fullurl = $url->out(false);
         } catch (\Throwable $e) {
             // A URL we cannot encode can never match a rule, so don't let it fatal the request.
             debugging('tool_redirects: could not encode URL for rule matching: ' .
@@ -108,7 +112,8 @@ class redirect_rule {
             return false;
         }
 
-        return (preg_match($this->config->regex, $localurl) == 1);
+        return (preg_match($this->config->regex, $localurl) == 1
+            || preg_match($this->config->regex, $fullurl) == 1);
     }
 
     /**

--- a/lang/en/tool_redirects.php
+++ b/lang/en/tool_redirects.php
@@ -43,6 +43,10 @@ $string['rules_desc'] = '<p>Each line should be a redirect rule like [php regex 
 #\/index\.php#=>/some-other-page
 #\/index\.php#=>https://some.other.site.com/
 </pre>
+<p>Rules are matched against both the local path AND the full URL (including the host), so you can target a specific tenant / custom domain, eg redirect only one tenant\'s root to its login page for logged-out users:</p>
+<pre>
+#^https:\/\/example.com\/(index\.php)?#=>http://example.com/login/index.php=>loggedout
+</pre>
 <p>You can also use the following tokens in the redirect url which will be dynamcially added:<p>
 <pre>
 [SESSKEY] - use with care to not open up XSS vulnerabilities

--- a/tests/phpunit/redirect_rule_test.php
+++ b/tests/phpunit/redirect_rule_test.php
@@ -188,4 +188,21 @@ final class redirect_rule_test extends \advanced_testcase {
         $this->assertFalse($rule->should_redirect($url));
         $this->assertDebuggingCalled();
     }
+
+    /**
+     * Test that a rule can match the full URL (including host) to target a specific tenant domain.
+     */
+    public function test_should_redirect_matches_full_url_host(): void {
+        $this->setAdminUser();
+
+        // Rule targets a specific host only.
+        $this->configdata['regex'] = '#^http://example.com/index\.php#';
+
+        $config = new \tool_redirects\rule_config($this->configdata);
+        $validator = new \tool_redirects\regex_validator($config->regex);
+        $rule = new \tool_redirects\redirect_rule($config, $validator);
+
+        // Matching host — should redirect.
+        $this->assertTrue($rule->should_redirect(new \moodle_url('http://example.com/index.php')));
+    }
 }

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026020303;
-$plugin->release   = 2026020303; // Match release exactly to version.
+$plugin->version   = 2026020304;
+$plugin->release   = 2026020304; // Match release exactly to version.
 $plugin->requires  = 2022112800; // Moodle 4.1.
 $plugin->component = 'tool_redirects';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
## Feature request: Full URL matching for redirect rules

### Summary

Please support redirect rule matching against the full request URL (scheme + host + path), not only the local path.

### Why this matters

In MWP multi-tenant deployments, each tenant can use a different domain.
Path-only matching is not enough when redirects must target a specific tenant domain.

### Proposed behavior

A rule should be considered a match when either condition is true:
1. regex matches local path
2. regex matches full URL (scheme + host + path)

### Example patterns

~~~text
#^https:\/\/tenant-a\.example\.com\/(index\.php)?#=>https://tenant-a.example.com/my/courses.php  (Redirect tenanta A to MY courses page)
#^https:\/\/tenant-b\.example\.com\/(index\.php)?#=>https://tenant-b.example.com/my/  (Redirect tenant B to dashboard page)
~~~

### Expected benefit

- tenant-specific redirects without plugin forks
- safer domain-scoped redirect behavior
- better support for MWP multi-tenant environments

### Suggested acceptance criteria

- existing path-based rules continue to work
- host-based full URL rules are supported
- PHPUnit includes full URL host-matching coverage
- admin help text includes domain-based examples

### Testing instructions

Manual checks:
- add a rule using a host-specific regex and verify redirect triggers on that tenant domain
- verify the same host-specific rule does not trigger on a different tenant domain
- add a path-only rule and verify existing behavior is unchanged

Automated checks (PHPUnit):
- add coverage to assert full URL host matching returns true for a matching host
- add coverage to assert full URL host matching returns false for a non-matching host
- keep path-only matching tests to confirm backward compatibility
